### PR TITLE
Added cross-compilation fix

### DIFF
--- a/recipes/apr/all/conandata.yml
+++ b/recipes/apr/all/conandata.yml
@@ -16,3 +16,5 @@ patches:
       patch_file: "patches/0005-clang12-apple.patch"
     - base_path: "source_subfolder"
       patch_file: "patches/0006-sys_siglist-fix.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0007-cross-compile-fix-gen_test_char.patch"

--- a/recipes/apr/all/patches/0007-cross-compile-fix-gen_test_char.patch
+++ b/recipes/apr/all/patches/0007-cross-compile-fix-gen_test_char.patch
@@ -1,33 +1,12 @@
 --- Makefile.in
 +++ Makefile.in
-@@ -45,8 +45,8 @@ 
- @INCLUDE_OUTPUTS@
- 
- CLEAN_TARGETS = apr-config.out apr.exp exports.c export_vars.c .make.dirs \
--	build/apr_rules.out tools/gen_test_char@EXEEXT@ \
--	tools/gen_test_char.o tools/gen_test_char.lo \
-+	build/apr_rules.out tools/gen_test_char \
-+	tools/gen_test_char.o \
- 	include/private/apr_escape_test_char.h
- DISTCLEAN_TARGETS = config.cache config.log config.status \
- 	include/apr.h include/arch/unix/apr_private.h \
-@@ -134,14 +134,14 @@ etags:
+@@ -134,7 +134,7 @@ 
  OBJECTS_gen_test_char = tools/gen_test_char.lo $(LOCAL_LIBS)
  tools/gen_test_char.lo: tools/gen_test_char.c
  	$(APR_MKDIR) tools
 -	$(LT_COMPILE)
 +	gcc -c $< -o $@
  
--tools/gen_test_char@EXEEXT@: $(OBJECTS_gen_test_char)
+ tools/gen_test_char@EXEEXT@: $(OBJECTS_gen_test_char)
 -	$(LINK_PROG) $(OBJECTS_gen_test_char) $(ALL_LIBS)
-+tools/gen_test_char: $(OBJECTS_gen_test_char)
-+	gcc $(OBJECTS_gen_test_char) -o $@
- 
--include/private/apr_escape_test_char.h: tools/gen_test_char@EXEEXT@
-+include/private/apr_escape_test_char.h: tools/gen_test_char
- 	$(APR_MKDIR) include/private
--	tools/gen_test_char@EXEEXT@ > $@
-+	tools/gen_test_char > $@
- 
- LINK_PROG = $(LIBTOOL) $(LTFLAGS) --mode=link $(COMPILE) $(LT_LDFLAGS) \
- 	    @LT_NO_INSTALL@ $(ALL_LDFLAGS) -o $@
++	gcc $(OBJECTS_gen_test_char@EXEEXT@) -o $@

--- a/recipes/apr/all/patches/0007-cross-compile-fix-gen_test_char.patch
+++ b/recipes/apr/all/patches/0007-cross-compile-fix-gen_test_char.patch
@@ -1,0 +1,33 @@
+--- Makefile.in
++++ Makefile.in
+@@ -45,8 +45,8 @@ 
+ @INCLUDE_OUTPUTS@
+ 
+ CLEAN_TARGETS = apr-config.out apr.exp exports.c export_vars.c .make.dirs \
+-	build/apr_rules.out tools/gen_test_char@EXEEXT@ \
+-	tools/gen_test_char.o tools/gen_test_char.lo \
++	build/apr_rules.out tools/gen_test_char \
++	tools/gen_test_char.o \
+ 	include/private/apr_escape_test_char.h
+ DISTCLEAN_TARGETS = config.cache config.log config.status \
+ 	include/apr.h include/arch/unix/apr_private.h \
+@@ -134,14 +134,14 @@ etags:
+ OBJECTS_gen_test_char = tools/gen_test_char.lo $(LOCAL_LIBS)
+ tools/gen_test_char.lo: tools/gen_test_char.c
+ 	$(APR_MKDIR) tools
+-	$(LT_COMPILE)
++	gcc -c $< -o $@
+ 
+-tools/gen_test_char@EXEEXT@: $(OBJECTS_gen_test_char)
+-	$(LINK_PROG) $(OBJECTS_gen_test_char) $(ALL_LIBS)
++tools/gen_test_char: $(OBJECTS_gen_test_char)
++	gcc $(OBJECTS_gen_test_char) -o $@
+ 
+-include/private/apr_escape_test_char.h: tools/gen_test_char@EXEEXT@
++include/private/apr_escape_test_char.h: tools/gen_test_char
+ 	$(APR_MKDIR) include/private
+-	tools/gen_test_char@EXEEXT@ > $@
++	tools/gen_test_char > $@
+ 
+ LINK_PROG = $(LIBTOOL) $(LTFLAGS) --mode=link $(COMPILE) $(LT_LDFLAGS) \
+ 	    @LT_NO_INSTALL@ $(ALL_LDFLAGS) -o $@


### PR DESCRIPTION
builds tools/gen_test_char.c for the local machine - fixes the build error when cross compiling

**apr/1.7.0**
Cross compilation of APR 1.7.0 fails when compiling on x86_64 targeting ARM. The file tools/gen_test_char.c is compiled and run during the configure stage to create another file (tools/gen_test_char > include/private/apr_escape_test_char.h), this file is platform independent with respect to x86 and ARM. Hence, the new patch instructs the system to build gen_test_char for the build host.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
